### PR TITLE
Use distro package

### DIFF
--- a/fetchy/dependency.py
+++ b/fetchy/dependency.py
@@ -115,28 +115,31 @@ class Dependency(object):
 
 class SimpleDependency(Dependency):
     def __init__(self, kind, name, relationship, condition):
-        """A Simple Dependency Object
+        """
+        A Simple Depency Object is a combination of a name and optionally
+        a version specifier.
 
-        A Simple Depency Object is a combination
-        of a name, optionally relationship and optionally
-        a condition.
+        Only the name of a Dependency is neccesary. If no version specifier
+        is given then the latest package is used as a dependency.
 
-        The name identifies the package that is to
-        be looked up.
+        A version specifier may be supplied to give a constraint on which
+        package may be a suitable dependency.
 
-        The relationship optionally specifies the version 
-        that is required to be installed.
+        Lastly, a dependency may have an optional condition under which
+        it should be (or should not) be installed.
 
-        Possible versions are:
-        - `<<`, strictly earlier
-        - `<=`, earlier or equal
-        - `=`,  equal
-        - `>=`, later or equal
-        - `>>`, strictly later
+        Parameters
+        ----------
+        kind : string representing if this dependency is either a
+            `Pre-Dependency` or `Dependency`.
+        
+        name : string representing the name of this dependency.
 
-        A condition can be optionally supplied. A 
-        condition can be used to specify which dependency
-        should be installed with respect to the architecture.
+        rerlationship : the version specifier for this dependency must be
+            an instance of :DependencyRelationship:.
+
+        condition : a boolean condition under which this dependency
+            must or must not be used.
         """
         super().__init__(kind)
         self.name = name

--- a/fetchy/downloader.py
+++ b/fetchy/downloader.py
@@ -10,8 +10,6 @@ logger = logging.getLogger(__name__)
 class Downloader(object):
     def __init__(self, packages, mirror=None, out_dir="./out"):
         """
-        A Downloader Object
-
         The Downloader class is responsible for downloading packages and it's dependencies.
 
         Parameters

--- a/fetchy/downloader.py
+++ b/fetchy/downloader.py
@@ -9,24 +9,41 @@ logger = logging.getLogger(__name__)
 
 class Downloader(object):
     def __init__(self, packages, mirror=None, out_dir="./out"):
-        """A Downloader Object
+        """
+        A Downloader Object
 
-        The Downloader class is responsible for
-        downloading packages and it's dependencies.
+        The Downloader class is responsible for downloading packages and it's dependencies.
+
+        Parameters
+        ----------
+        packages : a dictionary containing a collection of packages this
+            Downloader may use to satisfy dependencies.
+        
+        mirror : the url of the mirror that will be used when downloading
+            packages.
+
+        out_dir : the output directory this Downloader will download packages
+            into.
         """
         self.packages = packages
         self.mirror = mirror
         self.out_dir = out_dir
 
-    def download_package(self, package_name, version=None, architecture=None):
-        """Function for downloading a package
+    def download_package(self, package_name, version=None):
+        """
+        Downloads a package and its' dependencies into a folder.
 
-        This function downloads the specified
-        package name with the supplied version
-        and architecture when given.
+        Before downloading any package, the dependencies of the given
+        package are first gathered into a list of dependencies.
 
-        Furthermore, all dependencies for the
-        package are also downloaded.
+        Then, once all dependencies are determined, each dependency
+        is downloaded into the folder this Downloader has been configured
+        to use as an output directory.
+
+        Parameters
+        ----------
+        package_name : string representing the name of the package
+            that should be downloaded.
         """
         if not os.path.isdir(self.out_dir):
             logger.info(f"Creating output directory {self.out_dir}")
@@ -55,13 +72,25 @@ class Downloader(object):
                 urllib.request.urlretrieve(package_url, package_file, hook)
 
     def gather_dependencies(self, package_name):
-        """Function for gathering dependencies
+        """
+        Gather dependencies for a package.
 
-        This function will naaively gather
-        dependencies for the given package.
+        This function will naaively gather dependencies for the given package name.
 
-        This will only gather Depends and
-        Pre-Depends dependencies.
+        This will only gather Depends and Pre-Depends dependencies and thus only gather
+        the dependencies that are required in order to make the given package run.
+
+        Parameters
+        ----------
+        package_name : string representing the name of the package
+            dependencies should be gathereed for.
+        
+        Returns
+        -------
+        dict
+            A dictionary containing all the dependencies required for
+            the given package. Each dependency is stored as a Package
+            object and uses the package name as key.
         """
         queue = [package_name]
 

--- a/fetchy/utils.py
+++ b/fetchy/utils.py
@@ -1,6 +1,7 @@
 import os
 import gzip
 import urllib
+import distro
 import shutil
 import platform
 import logging
@@ -16,8 +17,7 @@ def get_distribution():
     This function will return the current distribution
     if the user is running on a Linux machine.
     """
-    (distribution, _, _) = platform.linux_distribution()
-    return distribution.lower()
+    return distro.id()
 
 
 def get_distribution_version():
@@ -26,8 +26,7 @@ def get_distribution_version():
     This function will return the current distribution version
     if the user is running on a Linux machine.
     """
-    (_, _, distribution_version) = platform.linux_distribution()
-    return distribution_version.lower()
+    return distro.codename()
 
 
 def get_architecture():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/ThomasKluiters/fetchy"
 [tool.poetry.dependencies]
 python = "^3.6"
 tqdm = "^4.32"
+distro = "^1.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ tqdm = "^4.32"
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"
 black = { version = "*", allows-prereleases = true }
-
-[build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+flake8 = "3.7.8"
 
 [tool.poetry.scripts]
 fetchy = 'fetchy:cli'
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 [tool.poetry]
 name = "fetchy"
 version = "0.1.0"
-description = ""
+description = "Downloading packages made easy!"
 authors = ["thomas <thomas.kluiters@gmail.com>"]
+homepage = "https://github.com/ThomasKluiters/fetchy"
+repository = "https://github.com/ThomasKluiters/fetchy"
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
Fixes #1 

As `platform.linux_distribution` is getting removed in Python 3.8, `distro` is an alternative.