### PR TITLE
FIX: #4 Store packages as their original filename

### DIFF
--- a/fetchy/downloader.py
+++ b/fetchy/downloader.py
@@ -50,7 +50,7 @@ class Downloader(object):
         logger.info(f"Gathering dependencies for {package_name}")
         for (name, package) in self.gather_dependencies(package_name).items():
             package_url = f"{self.mirror}/{package.file_name()}"
-            package_file = f"{self.out_dir}/{name}-{package.version}.deb"
+            package_file = f"{self.out_dir}/{os.path.basename(package.file_name())}"
 
             logger.info(f"Downloading package {name} at {package_url}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,3 @@ flake8 = "3.7.8"
 
 [tool.poetry.scripts]
 fetchy = 'fetchy:cli'
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
-


### PR DESCRIPTION
Package installation tools rely on package names being consistent, this pull request will fix this issue by storing packages with thier original file name.